### PR TITLE
NetAddr: Derive PartialEq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::net::IpAddr;
 ///
 /// Internally using the built-in `std::net::IpAddr` structures, this is a
 /// simple data structure that can be used in a variety of situations.
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord)]
 pub struct NetAddr {
 	pub netmask: IpAddr,
 	pub network: IpAddr,
@@ -173,29 +173,6 @@ impl PartialOrd for NetAddr {
 			Some(ordering) => Some(ordering),
 			None => None,
 		}
-	}
-}
-
-impl PartialEq for NetAddr {
-	/// Check two `NetAddr`s for equality.
-	///
-	/// Two `NetAddr`s are the same if they have the same network address and
-	/// netmask.
-	///
-	/// # Examples
-	///
-	/// In this example, two networks of the same netmask but unequal network
-	/// addresses are compared.
-	///
-	/// ```
-	/// let a: netaddr2::NetAddr = "1.1.1.1/32".parse().unwrap();
-	/// let b: netaddr2::NetAddr = "2.2.2.2/32".parse().unwrap();
-	/// assert!(!a.eq(&b));
-	/// // or, more concisely:
-	/// assert!(a != b);
-	/// ```
-	fn eq(&self, other: &Self) -> bool {
-		self.network.eq(&other.network) && self.netmask.eq(&other.netmask)
 	}
 }
 


### PR DESCRIPTION
In response to a Clippy lint suggesting that deriving `Hash` but manually implementing `PartialEq` was an antipattern, I made the discovery that I can just `#[derive(PartialEq)]`, which will just check the
fields for pairwise equality and `ops::And` the results together.

Looks much cleaner!