### PR TITLE
Turn the NetAddr struct into an Enum, reorganize a lot

### DIFF
--- a/benches/mask.rs
+++ b/benches/mask.rs
@@ -5,12 +5,12 @@ extern crate test;
 extern crate netaddr2;
 use netaddr2::mask;
 
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 #[bench]
 fn bench_mask(bencher: &mut test::Bencher) {
-	let a: IpAddr = "127.0.0.1".parse().unwrap();
-	let b: IpAddr = "255.255.255.0".parse().unwrap();
+	let a: Ipv4Addr = "127.0.0.1".parse().unwrap();
+	let b: Ipv4Addr = "255.255.255.0".parse().unwrap();
 
-	bencher.iter(|| test::black_box(mask(&a, &b)))
+	bencher.iter(|| test::black_box(mask::<Ipv4Addr, u32>(&a, &b)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,7 @@ impl NetAddr {
 					None
 				}
 			}
-			(IpAddr::V6(_net), IpAddr::V6(_mask), IpAddr::V6(_other_net), IpAddr::V6(_other_mask)) => {
-				unimplemented!()
-			}
+			(IpAddr::V6(_net), IpAddr::V6(_mask), IpAddr::V6(_other_net), IpAddr::V6(_other_mask)) => unimplemented!(),
 			(_, _, _, _) => unimplemented!(),
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,13 @@ where
 }
 
 impl NetAddr {
+	const F32: u32 = u32::max_value();
+	const F128: u128 = u128::max_value();
+	const F32V4: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 255);
+	const F32V6: Ipv6Addr = Ipv6Addr::new(
+		0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	);
+
 	pub fn contains<T>(&self, other: &T) -> bool
 	where
 		T: Copy,
@@ -163,13 +170,11 @@ impl From<IpAddr> for NetAddr {
 		match addr {
 			IpAddr::V4(addr) => NetAddr::V4 {
 				network: addr,
-				netmask: Ipv4Addr::new(255, 255, 255, 255),
+				netmask: NetAddr::F32V4,
 			},
 			IpAddr::V6(addr) => NetAddr::V6 {
 				network: addr,
-				netmask: Ipv6Addr::new(
-					0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
-				),
+				netmask: NetAddr::F32V6,
 			},
 		}
 	}
@@ -179,7 +184,7 @@ impl From<Ipv4Addr> for NetAddr {
 	fn from(addr: Ipv4Addr) -> Self {
 		NetAddr::V4 {
 			network: addr,
-			netmask: Ipv4Addr::new(0xff, 0xff, 0xff, 0xff),
+			netmask: NetAddr::F32V4,
 		}
 	}
 }
@@ -188,9 +193,7 @@ impl From<Ipv6Addr> for NetAddr {
 	fn from(addr: Ipv6Addr) -> Self {
 		NetAddr::V6 {
 			network: addr,
-			netmask: Ipv6Addr::new(
-				0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
-			),
+			netmask: NetAddr::F32V6,
 		}
 	}
 }
@@ -212,8 +215,8 @@ impl FromStr for NetAddr {
 
 		match (address, as_u32, as_ipaddr) {
 			(Ok(IpAddr::V4(address)), Ok(cidr_prefix_length), _) => {
-				let mask: u32 = 0xff_ff_ff_ff_u32
-					^ match 0xff_ff_ff_ff_u32.checked_shr(cidr_prefix_length) {
+				let mask: u32 = NetAddr::F32
+					^ match NetAddr::F32.checked_shr(cidr_prefix_length) {
 						Some(k) => k,
 						None => 0_u32,
 					};
@@ -228,8 +231,8 @@ impl FromStr for NetAddr {
 				})
 			}
 			(Ok(IpAddr::V6(address)), Ok(cidr_prefix_length), _) => {
-				let mask: u128 = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128
-					^ match 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128.checked_shr(cidr_prefix_length) {
+				let mask: u128 = NetAddr::F128
+					^ match NetAddr::F128.checked_shr(cidr_prefix_length) {
 						Some(k) => k,
 						None => 0_u128,
 					};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,16 +51,19 @@ impl std::convert::From<std::net::AddrParseError> for NetAddrError {
 /// Both `addr` and `mask` must be of the same `enum` variant for the
 /// operation to succeed.
 ///
-/// # Panics
+/// Because this method is a generic, you will need to be sure to use type
+/// annotations to specify which types it runs on.  For `Ipv4Addr` masking, you
+/// should use `::<Ipv4Addr, u32>` and for `Ipv6Addr` masking, the best choice
+/// is `::<Ipv6Addr, u128>`.  The Rust compiler will complain if you try to do
+/// this with incompatible types.
 ///
-/// This function will panic if the provided `addr` and `mask` are not of the
-/// same enum variant.
+/// # Examples
 ///
 /// ```
 /// # use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// let addr = Ipv4Addr::new(127, 0, 0, 1);
 /// let mask = Ipv4Addr::new(255, 0, 0, 0);
-/// netaddr2::mask::<Ipv4Addr, u32>(&addr, &mask);
+/// assert_eq!(netaddr2::mask::<Ipv4Addr, u32>(&addr, &mask), Ipv4Addr::new(127, 0, 0, 0));
 /// ```
 pub fn mask<T, U>(addr: &T, mask: &T) -> T
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ impl NetAddr {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum NetAddrError {
 	ParseError(String),
 }

--- a/src/tests/netaddr.rs
+++ b/src/tests/netaddr.rs
@@ -1,4 +1,4 @@
-use crate::NetAddr;
+use crate::*;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/src/tests/netaddr/cmp.rs
+++ b/src/tests/netaddr/cmp.rs
@@ -1,11 +1,13 @@
 use super::*;
 
+use std::cmp::Ordering;
+
 #[test]
 fn v4_different_networks() {
 	let a: NetAddr = "1.0.0.0/8".parse().unwrap();
 	let b: NetAddr = "2.0.0.0/8".parse().unwrap();
 
-	assert_eq!(a.partial_cmp(&b), Some(std::cmp::Ordering::Less))
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Less))
 }
 
 #[test]
@@ -13,7 +15,7 @@ fn v4_different_netmasks() {
 	let a: NetAddr = "1.0.0.0/7".parse().unwrap();
 	let b: NetAddr = "1.0.0.0/8".parse().unwrap();
 
-	assert_eq!(a.partial_cmp(&b), Some(std::cmp::Ordering::Less))
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Less))
 }
 
 #[test]
@@ -21,7 +23,7 @@ fn v4_different() {
 	let a: NetAddr = "1.0.0.0/8".parse().unwrap();
 	let b: NetAddr = "0.0.0.0/24".parse().unwrap();
 
-	assert_eq!(a.partial_cmp(&b), Some(std::cmp::Ordering::Greater))
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater))
 }
 
 #[test]
@@ -29,5 +31,37 @@ fn v4_equal() {
 	let a: NetAddr = "1.0.0.0/8".parse().unwrap();
 	let b: NetAddr = "1.0.0.0/8".parse().unwrap();
 
-	assert_eq!(a.partial_cmp(&b), Some(std::cmp::Ordering::Equal))
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal))
+}
+
+#[test]
+fn v6_different_networks() {
+	let a: NetAddr = "2001:db8:0:0::0/64".parse().unwrap();
+	let b: NetAddr = "2001:db8:0:1::0/64".parse().unwrap();
+
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Less))
+}
+
+#[test]
+fn v6_different_netmasks() {
+	let a: NetAddr = "2001:db8:0:0::0/63".parse().unwrap();
+	let b: NetAddr = "2001:db8:0:0::0/64".parse().unwrap();
+
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Less))
+}
+
+#[test]
+fn v6_different() {
+	let a: NetAddr = "ff02::1/16".parse().unwrap();
+	let b: NetAddr = "2001:db8:0:1::0/64".parse().unwrap();
+
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater))
+}
+
+#[test]
+fn v6_equal() {
+	let a: NetAddr = "2001:db8:dead:beef::0/64".parse().unwrap();
+	let b: NetAddr = "2001:db8:dead:beef::0/64".parse().unwrap();
+
+	assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal))
 }

--- a/src/tests/netaddr/contains.rs
+++ b/src/tests/netaddr/contains.rs
@@ -35,3 +35,35 @@ fn v6_net() {
 	let net_inner: NetAddr = "2001:db8:d00b::/48".parse().unwrap();
 	assert!(net.contains(&net_inner));
 }
+
+#[test]
+#[should_panic]
+fn v4_v6_ip() {
+	let net: NetAddr = "127.0.0.1/8".parse().unwrap();
+	let ip: IpAddr = "2001:db8:d00b::1".parse().unwrap();
+	assert!(!net.contains(&ip));
+}
+
+#[test]
+#[should_panic]
+fn v4_v6_net() {
+	let a: NetAddr = "127.0.0.1/8".parse().unwrap();
+	let b: IpAddr = "2001:db8:d0::/48".parse().unwrap();
+	assert!(!a.contains(&b));
+}
+
+#[test]
+#[should_panic]
+fn v6_v4_ip() {
+	let net: NetAddr = "2001:db8:d000::/40".parse().unwrap();
+	let ip: IpAddr = "127.0.0.1".parse().unwrap();
+	assert!(!net.contains(&ip));
+}
+
+#[test]
+#[should_panic]
+fn v6_v4_net() {
+	let a: NetAddr = "2001:db8:d0::/48".parse().unwrap();
+	let b: IpAddr = "127.0.0.1/8".parse().unwrap();
+	assert!(!a.contains(&b));
+}

--- a/src/tests/netaddr/contains.rs
+++ b/src/tests/netaddr/contains.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn v4_seems_correct() {
+fn v4_ip() {
 	let net: NetAddr = "127.0.0.1/8".parse().unwrap();
 	assert!(net.contains(&IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
 	assert!(net.contains(&IpAddr::V4(Ipv4Addr::new(127, 127, 255, 1))));
@@ -9,9 +9,29 @@ fn v4_seems_correct() {
 }
 
 #[test]
-fn v6_seems_correct() {
+fn v4_net() {
 	let net: NetAddr = "127.0.0.1/8".parse().unwrap();
-	assert!(net.contains(&IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
-	assert!(net.contains(&IpAddr::V4(Ipv4Addr::new(127, 127, 255, 1))));
-	assert!(!net.contains(&IpAddr::V4(Ipv4Addr::new(64, 0, 0, 0))));
+	let net_inner: NetAddr = "127.128.0.1/24".parse().unwrap();
+	assert!(net.contains(&net_inner));
+}
+
+#[test]
+fn v6_ip() {
+	let net: NetAddr = "2001:db8:d00b::/48".parse().unwrap();
+	assert!(net.contains(&IpAddr::V6(Ipv6Addr::new(
+		0x2001, 0x0db8, 0xd00b, 0, 0, 0, 0, 0x0001
+	))));
+	assert!(net.contains(&IpAddr::V6(Ipv6Addr::new(
+		0x2001, 0x0db8, 0xd00b, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff
+	))));
+	assert!(!net.contains(&IpAddr::V6(Ipv6Addr::new(
+		0x2001, 0x0db8, 0xd00c, 0, 0, 0, 0, 1
+	))));
+}
+
+#[test]
+fn v6_net() {
+	let net: NetAddr = "2001:db8:d000::/40".parse().unwrap();
+	let net_inner: NetAddr = "2001:db8:d00b::/48".parse().unwrap();
+	assert!(net.contains(&net_inner));
 }

--- a/src/tests/netaddr/from/ipaddr.rs
+++ b/src/tests/netaddr/from/ipaddr.rs
@@ -2,24 +2,24 @@ use super::*;
 
 #[test]
 fn v4_returns_full_netmask() {
-	let addr: IpAddr = "192.0.2.42".parse().unwrap();
+	let addr: Ipv4Addr = "192.0.2.42".parse().unwrap();
 	assert_eq!(
 		NetAddr::from(addr),
-		NetAddr {
+		NetAddr::V4 {
 			network: addr,
-			netmask: IpAddr::V4(Ipv4Addr::from(0xff_ff_ff_ff))
+			netmask: Ipv4Addr::from(0xff_ff_ff_ff)
 		}
 	);
 }
 
 #[test]
 fn v6_returns_full_netmask() {
-	let addr: IpAddr = "2001:db8:dead:beef::42".parse().unwrap();
+	let addr: Ipv6Addr = "2001:db8:dead:beef::42".parse().unwrap();
 	assert_eq!(
 		NetAddr::from(addr),
-		NetAddr {
+		NetAddr::V6 {
 			network: addr,
-			netmask: IpAddr::V6(Ipv6Addr::from(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff))
+			netmask: Ipv6Addr::from(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff)
 		}
 	);
 }

--- a/src/tests/netaddr/parse.rs
+++ b/src/tests/netaddr/parse.rs
@@ -8,47 +8,47 @@ fn invalid_is_safe() {
 #[test]
 fn v4_correct_network() {
 	let net: NetAddr = "192.0.2.0/32".parse().unwrap();
-	assert_eq!(net.netmask, IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)));
-	assert_eq!(net.network, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)));
+	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)));
+	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)));
 }
 
 #[test]
 fn v4_localhost() {
 	let net: NetAddr = "127.0.0.1/8".parse().unwrap();
-	assert_eq!(net.netmask, IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
-	assert_eq!(net.network, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
+	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
+	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
 }
 
 #[test]
 fn v4_cidr_22() {
 	let net: NetAddr = "192.168.16.1/22".parse().unwrap();
-	assert_eq!(net.netmask, IpAddr::V4(Ipv4Addr::new(255, 255, 252, 0)));
-	assert_eq!(net.network, IpAddr::V4(Ipv4Addr::new(192, 168, 16, 0)));
+	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 255, 252, 0)));
+	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(192, 168, 16, 0)));
 }
 
 #[test]
 fn v4_extended_localhost() {
 	let net: NetAddr = "127.0.0.1 255.0.0.0".parse().unwrap();
-	assert_eq!(net.netmask, IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
-	assert_eq!(net.network, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
+	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
+	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
 }
 
 #[test]
 fn v4_slashed_localhost() {
 	let net: NetAddr = "127.0.0.1/255.0.0.0".parse().unwrap();
-	assert_eq!(net.netmask, IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
-	assert_eq!(net.network, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
+	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
+	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
 }
 
 #[test]
 fn v6_cidr_8() {
 	let net: NetAddr = "ff02::1/8".parse().unwrap();
 	assert_eq!(
-		net.netmask,
+		net.netmask(),
 		IpAddr::V6(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0x0000))
 	);
 	assert_eq!(
-		net.network,
+		net.network(),
 		IpAddr::V6(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0x0000))
 	);
 }
@@ -57,13 +57,13 @@ fn v6_cidr_8() {
 fn v6_cidr_128() {
 	let net: NetAddr = "ff02::1/128".parse().unwrap();
 	assert_eq!(
-		net.netmask,
+		net.netmask(),
 		IpAddr::V6(Ipv6Addr::new(
 			0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff
 		))
 	);
 	assert_eq!(
-		net.network,
+		net.network(),
 		IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0001))
 	);
 }

--- a/src/tests/netaddr/parse.rs
+++ b/src/tests/netaddr/parse.rs
@@ -95,3 +95,47 @@ fn v6_slashed() {
 		IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0001))
 	);
 }
+
+#[test]
+fn addr_only() {
+	let net: NetAddr = "127.0.0.1/zoop".parse().unwrap();
+	assert_eq!(net, "127.0.0.1/32".parse().unwrap());
+}
+
+#[test]
+fn addr_no_mask_returns_full_bitstring() {
+	let net: NetAddr = "127.0.0.1/zoop".parse().unwrap();
+	assert_eq!(net, "127.0.0.1/32".parse().unwrap());
+	let net: NetAddr = "ff02::1/zoop".parse().unwrap();
+	assert_eq!(net, "ff02::1/128".parse().unwrap());
+}
+
+#[test]
+fn non_addr_passes_out_error() {
+	let result = "zoop".parse::<NetAddr>();
+	assert_eq!(
+		result,
+		Err(NetAddrError::ParseError(
+			"could not split provided input".to_string()
+		))
+	);
+}
+
+#[test]
+fn mismatched_v4_v6_returns_error() {
+	let result = "127.0.0.1 ffff::0".parse::<NetAddr>();
+	assert_eq!(
+		result,
+		Err(NetAddrError::ParseError(
+			"mismatched types of network/netmask".to_string()
+		))
+	);
+
+	let result = "ff02::1 255.255.255.0".parse::<NetAddr>();
+	assert_eq!(
+		result,
+		Err(NetAddrError::ParseError(
+			"mismatched types of network/netmask".to_string()
+		))
+	);
+}

--- a/src/tests/netaddr/parse.rs
+++ b/src/tests/netaddr/parse.rs
@@ -13,7 +13,7 @@ fn v4_correct_network() {
 }
 
 #[test]
-fn v4_localhost() {
+fn v4_localhost_8() {
 	let net: NetAddr = "127.0.0.1/8".parse().unwrap();
 	assert_eq!(net.netmask(), IpAddr::V4(Ipv4Addr::new(255, 0, 0, 0)));
 	assert_eq!(net.network(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)));
@@ -55,6 +55,34 @@ fn v6_cidr_8() {
 
 #[test]
 fn v6_cidr_128() {
+	let net: NetAddr = "ff02::1/128".parse().unwrap();
+	assert_eq!(
+		net.netmask(),
+		IpAddr::V6(Ipv6Addr::new(
+			0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff
+		))
+	);
+	assert_eq!(
+		net.network(),
+		IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0001))
+	);
+}
+
+#[test]
+fn v6_extended() {
+	let net: NetAddr = "ff02::1 ffff::0".parse().unwrap();
+	assert_eq!(
+		net.netmask(),
+		IpAddr::V6(Ipv6Addr::new(0xffff, 0, 0, 0, 0, 0, 0, 0))
+	);
+	assert_eq!(
+		net.network(),
+		IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0))
+	);
+}
+
+#[test]
+fn v6_slashed() {
 	let net: NetAddr = "ff02::1/128".parse().unwrap();
 	assert_eq!(
 		net.netmask(),


### PR DESCRIPTION
This reduces some of the edge cases (can no longer have an `IpAddr::V4` and `IpAddr::V6` in the same `NetAddr`) and makes things a bit more rigid.

Tests have not changed that much besides to handle the change in API.