### PR TITLE
Implement the Display trait on Net{,v4,v6}Addr

### DIFF
--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -35,6 +35,7 @@ impl NetAddr {
 
 mod broadcast;
 mod contains;
+mod display;
 mod from;
 mod fromstr;
 mod hash;

--- a/src/netaddr/display.rs
+++ b/src/netaddr/display.rs
@@ -1,0 +1,11 @@
+use super::NetAddr;
+use core::fmt;
+
+impl fmt::Display for NetAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::V4(addr) => write!(f, "{}", addr),
+			Self::V6(addr) => write!(f, "{}", addr),
+		}
+	}
+}

--- a/src/netaddr/display.rs
+++ b/src/netaddr/display.rs
@@ -9,3 +9,61 @@ impl fmt::Display for NetAddr {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::NetAddr;
+
+	mod v4 {
+		use super::NetAddr;
+
+		#[test]
+		fn cidr() {
+			let addr: NetAddr = "127.0.0.1/0.0.0.0".parse().unwrap();
+			assert_eq!(format!("{}", addr), "0.0.0.0/0");
+
+			let addr: NetAddr = "127.0.0.1/255.255.255.0".parse().unwrap();
+			assert_eq!(format!("{}", addr), "127.0.0.0/24");
+
+			let addr: NetAddr = "127.0.0.1/255.255.255.255.".parse().unwrap();
+			assert_eq!(format!("{}", addr), "127.0.0.1/32");
+		}
+
+		#[test]
+		fn non_cidr() {
+			let addr: NetAddr = "127.0.0.1/251.255.255.0".parse().unwrap();
+			assert_eq!(format!("{}", addr), "123.0.0.0/251.255.255.0")
+		}
+	}
+
+	mod v6 {
+		use super::NetAddr;
+
+		#[test]
+		fn cidr() {
+			let addr: NetAddr = "2001:db8:dead:beef::/::".parse().unwrap();
+			assert_eq!(format!("{}", addr), "::/0");
+
+			let addr: NetAddr = "2001:db8:dead:beef::/ffff:ffff:ffff:fff0::"
+				.parse()
+				.unwrap();
+			assert_eq!(format!("{}", addr), "2001:db8:dead:bee0::/60");
+
+			let addr: NetAddr = "2001:db8:dead:beef::/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+				.parse()
+				.unwrap();
+			assert_eq!(format!("{}", addr), "2001:db8:dead:beef::/128");
+		}
+
+		#[test]
+		fn non_cidr() {
+			let addr: NetAddr = "2001:db8:dead:beef::/ffff:ffff:ffff:fddf::"
+				.parse()
+				.unwrap();
+			assert_eq!(
+				format!("{}", addr),
+				"2001:db8:dead:bccf::/ffff:ffff:ffff:fddf::"
+			)
+		}
+	}
+}

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -43,6 +43,7 @@ impl Netv4Addr {
 
 mod broadcast;
 mod contains;
+mod display;
 mod from;
 mod fromstr;
 mod hash;

--- a/src/netv4addr/display.rs
+++ b/src/netv4addr/display.rs
@@ -14,3 +14,31 @@ impl fmt::Display for Netv4Addr {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::Netv4Addr;
+
+	#[test]
+	fn cidr() {
+		// We test in three main cases:
+
+		// (i) The mask has zero bits... (shl must not fail)
+		let addr: Netv4Addr = "127.0.0.1/0.0.0.0".parse().unwrap();
+		assert_eq!(format!("{}", addr), "0.0.0.0/0");
+
+		// (ii) The mask has 0 < n < 32 bits...
+		let addr: Netv4Addr = "127.0.0.1/255.255.255.0".parse().unwrap();
+		assert_eq!(format!("{}", addr), "127.0.0.0/24");
+
+		// (iii) The mask has 32 bits...
+		let addr: Netv4Addr = "127.0.0.1/255.255.255.255.".parse().unwrap();
+		assert_eq!(format!("{}", addr), "127.0.0.1/32");
+	}
+
+	#[test]
+	fn non_cidr() {
+		let addr: Netv4Addr = "127.0.0.1/251.255.255.0".parse().unwrap();
+		assert_eq!(format!("{}", addr), "123.0.0.0/251.255.255.0")
+	}
+}

--- a/src/netv4addr/display.rs
+++ b/src/netv4addr/display.rs
@@ -1,0 +1,16 @@
+use super::Netv4Addr;
+use core::fmt;
+
+impl fmt::Display for Netv4Addr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let mask: u32 = (*self.mask()).into();
+		let ones = mask.count_ones();
+		let cidr_mask: u32 = u32::max_value().checked_shl(32 - ones).unwrap_or(0);
+
+		if mask == cidr_mask {
+			write!(f, "{}/{}", self.addr(), ones)
+		} else {
+			write!(f, "{}/{}", self.addr(), self.mask())
+		}
+	}
+}

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -42,6 +42,7 @@ impl Netv6Addr {
 }
 
 mod contains;
+mod display;
 mod from;
 mod fromstr;
 mod hash;

--- a/src/netv6addr/display.rs
+++ b/src/netv6addr/display.rs
@@ -14,3 +14,40 @@ impl fmt::Display for Netv6Addr {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::Netv6Addr;
+
+	#[test]
+	fn cidr() {
+		// We test in three main cases:
+
+		// (i) The mask has zero bits... (shl must not fail)
+		let addr: Netv6Addr = "2001:db8:dead:beef::/::".parse().unwrap();
+		assert_eq!(format!("{}", addr), "::/0");
+
+		// (ii) The mask has 0 < n < 128 bits...
+		let addr: Netv6Addr = "2001:db8:dead:beef::/ffff:ffff:ffff:fff0::"
+			.parse()
+			.unwrap();
+		assert_eq!(format!("{}", addr), "2001:db8:dead:bee0::/60");
+
+		// (iii) The mask has 128 bits...
+		let addr: Netv6Addr = "2001:db8:dead:beef::/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+			.parse()
+			.unwrap();
+		assert_eq!(format!("{}", addr), "2001:db8:dead:beef::/128");
+	}
+
+	#[test]
+	fn non_cidr() {
+		let addr: Netv6Addr = "2001:db8:dead:beef::/ffff:ffff:ffff:fddf::"
+			.parse()
+			.unwrap();
+		assert_eq!(
+			format!("{}", addr),
+			"2001:db8:dead:bccf::/ffff:ffff:ffff:fddf::"
+		)
+	}
+}

--- a/src/netv6addr/display.rs
+++ b/src/netv6addr/display.rs
@@ -1,0 +1,16 @@
+use super::Netv6Addr;
+use core::fmt;
+
+impl fmt::Display for Netv6Addr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let mask: u128 = (*self.mask()).into();
+		let ones = mask.count_ones();
+		let cidr_mask: u128 = u128::max_value().checked_shl(128 - ones).unwrap_or(0);
+
+		if mask == cidr_mask {
+			write!(f, "{}/{}", self.addr(), ones)
+		} else {
+			write!(f, "{}/{}", self.addr(), self.mask())
+		}
+	}
+}


### PR DESCRIPTION
Pretty much what it says on the tin.

This implementation does a check before deciding which output format to use, but this check is small enough that I don't think it'll matter too much.