### PR TITLE
tarpaulin: Enable all features when generating coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         cargo install --force cargo-tarpaulin
-        cargo tarpaulin --out Xml
+        cargo tarpaulin --all-features --out Xml
         bash <(curl -s https://codecov.io/bash)
     - uses: actions/upload-artifact@master
       with:


### PR DESCRIPTION
This might help the coverage woes with the `serde` feature on this crate (and future features I may add)