### PR TITLE
Error type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security -->
 
 ## Unreleased
+### Added
+- A new `Result<T, Error>` type, which is a sugar around the nascent `Error` type.
+
+### Changed
+- Renamed the `NetAddrError` type to just `Error`.
 
 ## [0.6.1] - 2019-11-18
 ### Added

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,3 +6,6 @@ pub enum Error {
 
 mod display;
 mod from;
+mod result;
+
+pub use result::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 /// The error type for operations relating to the `NetAddr` type.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum NetAddrError {
+pub enum Error {
 	ParseError(String),
 }
 

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -1,8 +1,8 @@
-use super::NetAddrError;
-use core::fmt::{Display, Error, Formatter};
+use super::Error;
+use core::fmt::{self, Display, Formatter};
 
-impl Display for NetAddrError {
-	fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+impl Display for Error {
+	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
 		match self {
 			Self::ParseError(text) => write!(f, "unable to parse address: {}", text),
 		}
@@ -15,7 +15,7 @@ mod tests {
 
 	#[test]
 	fn right_message() {
-		let error: NetAddrError = NetAddrError::ParseError("INNER_TEXT".into());
+		let error: Error = Error::ParseError("INNER_TEXT".into());
 		let result: &str = &format!("{}", error);
 		assert_eq!(result, "unable to parse address: INNER_TEXT");
 	}

--- a/src/error/from.rs
+++ b/src/error/from.rs
@@ -1,0 +1,3 @@
+use super::Error;
+
+mod addr_parse_error;

--- a/src/error/from/addr_parse_error.rs
+++ b/src/error/from/addr_parse_error.rs
@@ -1,7 +1,7 @@
-use super::NetAddrError;
+use super::Error;
 use std::net::AddrParseError;
 
-impl From<AddrParseError> for NetAddrError {
+impl From<AddrParseError> for Error {
 	fn from(other: AddrParseError) -> Self {
 		Self::ParseError(other.to_string())
 	}

--- a/src/error/result.rs
+++ b/src/error/result.rs
@@ -1,0 +1,3 @@
+use super::Error;
+
+pub type Result<T> = core::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! A crate for parsing, representing, and manipulating network addresses.
 
+mod error;
 mod netaddr;
-mod netaddr_error;
 mod netv4addr;
 mod netv6addr;
 mod traits;
 
+pub use error::*;
 pub use netaddr::*;
-pub use netaddr_error::*;
 pub use netv4addr::*;
 pub use netv6addr::*;
 pub use traits::*;

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -1,6 +1,6 @@
-use crate::{Error, Result};
 use crate::Netv4Addr;
 use crate::Netv6Addr;
+use crate::{Error, Result};
 use std::net::IpAddr;
 
 /// A structure representing an IP network.

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{Error, Result};
 use crate::Netv4Addr;
 use crate::Netv6Addr;
 use std::net::IpAddr;

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -1,4 +1,4 @@
-use crate::NetAddrError;
+use crate::Error;
 use crate::Netv4Addr;
 use crate::Netv6Addr;
 use std::net::IpAddr;

--- a/src/netaddr/fromstr.rs
+++ b/src/netaddr/fromstr.rs
@@ -1,4 +1,4 @@
-use super::{Error, NetAddr};
+use super::{Error, Result, NetAddr};
 use crate::Netv4Addr;
 use crate::Netv6Addr;
 use core::str::FromStr;
@@ -6,9 +6,9 @@ use core::str::FromStr;
 impl FromStr for NetAddr {
 	type Err = Error;
 
-	fn from_str(string: &str) -> Result<Self, Error> {
-		let as_v4: Result<Netv4Addr, Error> = string.parse::<Netv4Addr>();
-		let as_v6: Result<Netv6Addr, Error> = string.parse::<Netv6Addr>();
+	fn from_str(string: &str) -> Result<Self> {
+		let as_v4: Result<Netv4Addr> = string.parse::<Netv4Addr>();
+		let as_v6: Result<Netv6Addr> = string.parse::<Netv6Addr>();
 
 		match (as_v4, as_v6) {
 			(Ok(v4), _) => Ok(Self::V4(v4)),
@@ -24,7 +24,7 @@ mod tests {
 
 	#[test]
 	fn invalid_is_safe() {
-		let _: Result<NetAddr, _> = "zoop".parse::<NetAddr>();
+		let _: Result<NetAddr> = "zoop".parse::<NetAddr>();
 	}
 
 	#[test]

--- a/src/netaddr/fromstr.rs
+++ b/src/netaddr/fromstr.rs
@@ -1,4 +1,4 @@
-use super::{Error, Result, NetAddr};
+use super::{Error, NetAddr, Result};
 use crate::Netv4Addr;
 use crate::Netv6Addr;
 use core::str::FromStr;

--- a/src/netaddr/fromstr.rs
+++ b/src/netaddr/fromstr.rs
@@ -1,14 +1,14 @@
-use super::{NetAddr, NetAddrError};
+use super::{Error, NetAddr};
 use crate::Netv4Addr;
 use crate::Netv6Addr;
 use core::str::FromStr;
 
 impl FromStr for NetAddr {
-	type Err = NetAddrError;
+	type Err = Error;
 
-	fn from_str(string: &str) -> Result<Self, NetAddrError> {
-		let as_v4: Result<Netv4Addr, NetAddrError> = string.parse::<Netv4Addr>();
-		let as_v6: Result<Netv6Addr, NetAddrError> = string.parse::<Netv6Addr>();
+	fn from_str(string: &str) -> Result<Self, Error> {
+		let as_v4: Result<Netv4Addr, Error> = string.parse::<Netv4Addr>();
+		let as_v6: Result<Netv6Addr, Error> = string.parse::<Netv6Addr>();
 
 		match (as_v4, as_v6) {
 			(Ok(v4), _) => Ok(Self::V4(v4)),
@@ -40,7 +40,7 @@ mod tests {
 		let result = "zoop".parse::<NetAddr>();
 		assert_eq!(
 			result,
-			Err(NetAddrError::ParseError(
+			Err(Error::ParseError(
 				"could not split provided input".to_string()
 			))
 		);

--- a/src/netaddr_error/from.rs
+++ b/src/netaddr_error/from.rs
@@ -1,3 +1,0 @@
-use super::NetAddrError;
-
-mod addr_parse_error;

--- a/src/netv4addr/fromstr.rs
+++ b/src/netv4addr/fromstr.rs
@@ -1,5 +1,5 @@
 use super::Netv4Addr;
-use crate::Error;
+use crate::{Error, Result};
 use core::str::FromStr;
 use std::net::Ipv4Addr;
 
@@ -38,7 +38,7 @@ impl FromStr for Netv4Addr {
 	/// let mask: std::net::Ipv4Addr = "255.255.255.248".parse().unwrap();
 	/// assert_eq!(parsed, Netv4Addr::new(addr, mask));
 	/// ```
-	fn from_str(string: &str) -> Result<Self, Error> {
+	fn from_str(string: &str) -> Result<Self> {
 		let split: Vec<&str> = string.split(|c| c == '/' || c == ' ').collect();
 
 		let lhs: &str = split[0];
@@ -75,7 +75,7 @@ mod tests {
 
 	#[test]
 	fn invalid_is_safe() {
-		let _: Result<Netv4Addr, _> = "zoop".parse::<Netv4Addr>();
+		let _: Result<Netv4Addr> = "zoop".parse::<Netv4Addr>();
 	}
 
 	#[test]

--- a/src/netv4addr/fromstr.rs
+++ b/src/netv4addr/fromstr.rs
@@ -1,10 +1,10 @@
 use super::Netv4Addr;
-use crate::NetAddrError;
+use crate::Error;
 use core::str::FromStr;
 use std::net::Ipv4Addr;
 
 impl FromStr for Netv4Addr {
-	type Err = NetAddrError;
+	type Err = Error;
 
 	/// Parse a `Netv4Addr` from a string
 	///
@@ -38,13 +38,13 @@ impl FromStr for Netv4Addr {
 	/// let mask: std::net::Ipv4Addr = "255.255.255.248".parse().unwrap();
 	/// assert_eq!(parsed, Netv4Addr::new(addr, mask));
 	/// ```
-	fn from_str(string: &str) -> Result<Self, NetAddrError> {
+	fn from_str(string: &str) -> Result<Self, Error> {
 		let split: Vec<&str> = string.split(|c| c == '/' || c == ' ').collect();
 
 		let lhs: &str = split[0];
 		let rhs: &str = split
 			.get(1)
-			.ok_or_else(|| NetAddrError::ParseError("could not split provided input".to_string()))?;
+			.ok_or_else(|| Error::ParseError("could not split provided input".to_string()))?;
 
 		let address = lhs.parse::<Ipv4Addr>();
 		let cidr = rhs.parse::<u32>();
@@ -89,7 +89,7 @@ mod tests {
 		let result = "zoop".parse::<Netv4Addr>();
 		assert_eq!(
 			result,
-			Err(NetAddrError::ParseError(
+			Err(Error::ParseError(
 				"could not split provided input".to_string()
 			))
 		);

--- a/src/netv6addr/fromstr.rs
+++ b/src/netv6addr/fromstr.rs
@@ -1,5 +1,5 @@
 use super::Netv6Addr;
-use crate::Error;
+use crate::{Error, Result};
 use core::str::FromStr;
 use std::net::Ipv6Addr;
 
@@ -38,7 +38,7 @@ impl FromStr for Netv6Addr {
 	/// let mask: std::net::Ipv6Addr = "ffff:ffff::0".parse().unwrap();
 	/// assert_eq!(parsed, Netv6Addr::new(addr, mask))
 	/// ```
-	fn from_str(string: &str) -> Result<Self, Self::Err> {
+	fn from_str(string: &str) -> Result<Self> {
 		let split: Vec<&str> = string.split(|c| c == '/' || c == ' ').collect();
 
 		let lhs: &str = split[0];
@@ -75,7 +75,7 @@ mod tests {
 
 	#[test]
 	fn invalid_is_safe() {
-		let _: Result<Netv6Addr, _> = "zoop".parse::<Netv6Addr>();
+		let _: Result<Netv6Addr> = "zoop".parse::<Netv6Addr>();
 	}
 
 	#[test]

--- a/src/netv6addr/fromstr.rs
+++ b/src/netv6addr/fromstr.rs
@@ -1,10 +1,10 @@
 use super::Netv6Addr;
-use crate::NetAddrError;
+use crate::Error;
 use core::str::FromStr;
 use std::net::Ipv6Addr;
 
 impl FromStr for Netv6Addr {
-	type Err = NetAddrError;
+	type Err = Error;
 
 	/// Parse a `Netv6Addr` from a string
 	///
@@ -38,13 +38,13 @@ impl FromStr for Netv6Addr {
 	/// let mask: std::net::Ipv6Addr = "ffff:ffff::0".parse().unwrap();
 	/// assert_eq!(parsed, Netv6Addr::new(addr, mask))
 	/// ```
-	fn from_str(string: &str) -> Result<Self, NetAddrError> {
+	fn from_str(string: &str) -> Result<Self, Self::Err> {
 		let split: Vec<&str> = string.split(|c| c == '/' || c == ' ').collect();
 
 		let lhs: &str = split[0];
 		let rhs: &str = split
 			.get(1)
-			.ok_or_else(|| NetAddrError::ParseError("could not split provided input".to_string()))?;
+			.ok_or_else(|| Error::ParseError("could not split provided input".to_string()))?;
 
 		let address = lhs.parse::<Ipv6Addr>();
 		let cidr = rhs.parse::<u32>();
@@ -89,7 +89,7 @@ mod tests {
 		let result = "zoop".parse::<Netv6Addr>();
 		assert_eq!(
 			result,
-			Err(NetAddrError::ParseError(
+			Err(Error::ParseError(
 				"could not split provided input".to_string()
 			))
 		);


### PR DESCRIPTION
This PR includes two key changes: the renaming of the `NetAddrError` type to just `Error`, and the inclusion of a new `Result<T, Error>` thing.