### PR TITLE
Adjust serde::de error behavior and add tests for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security -->
 
 ## Unreleased
+### Changed
+- Updated the `serde::de` behavior to be slightly more informative and standard.
 
 ## [0.7.1] - 2019-01-12
 ### Added

--- a/src/netaddr/de.rs
+++ b/src/netaddr/de.rs
@@ -30,7 +30,15 @@ impl<'de> Deserialize<'de> for NetAddr {
 #[cfg(test)]
 mod tests {
 	use super::NetAddr;
-	use serde_test::{assert_de_tokens, Token};
+	use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+
+	#[test]
+	fn malformed_produces_correct_error() {
+		assert_de_tokens_error::<NetAddr>(
+			&[Token::Str("asdf")],
+			"invalid value: string \"asdf\", expected a valid cidr/extended network address",
+		)
+	}
 
 	mod v4 {
 		use super::*;

--- a/src/netaddr/de.rs
+++ b/src/netaddr/de.rs
@@ -15,7 +15,8 @@ impl<'de> de::Visitor<'de> for NetAddrVisitor {
 
 	fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
 		use core::str::FromStr;
-		Self::Value::from_str(value).map_err(de::Error::custom)
+		Self::Value::from_str(value)
+			.map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &self))
 	}
 }
 

--- a/src/netv4addr/de.rs
+++ b/src/netv4addr/de.rs
@@ -15,7 +15,8 @@ impl<'de> de::Visitor<'de> for Netv4AddrVisitor {
 
 	fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
 		use core::str::FromStr;
-		Self::Value::from_str(value).map_err(de::Error::custom)
+		Self::Value::from_str(value)
+			.map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &self))
 	}
 }
 

--- a/src/netv4addr/de.rs
+++ b/src/netv4addr/de.rs
@@ -30,7 +30,15 @@ impl<'de> Deserialize<'de> for Netv4Addr {
 #[cfg(test)]
 mod tests {
 	use super::Netv4Addr;
-	use serde_test::{assert_de_tokens, Token};
+	use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+
+	#[test]
+	fn malformed_produces_correct_error() {
+		assert_de_tokens_error::<Netv4Addr>(
+			&[Token::Str("asdf")],
+			"invalid value: string \"asdf\", expected a valid cidr/extended network address",
+		)
+	}
 
 	#[test]
 	fn test_de_cidr_localhost() {

--- a/src/netv6addr/de.rs
+++ b/src/netv6addr/de.rs
@@ -30,7 +30,15 @@ impl<'de> Deserialize<'de> for Netv6Addr {
 #[cfg(test)]
 mod tests {
 	use super::Netv6Addr;
-	use serde_test::{assert_de_tokens, Token};
+	use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+
+	#[test]
+	fn malformed_produces_correct_error() {
+		assert_de_tokens_error::<Netv6Addr>(
+			&[Token::Str("asdf")],
+			"invalid value: string \"asdf\", expected a valid cidr/extended network address",
+		)
+	}
 
 	#[test]
 	fn test_de_cidr_localhost() {

--- a/src/netv6addr/de.rs
+++ b/src/netv6addr/de.rs
@@ -15,7 +15,8 @@ impl<'de> de::Visitor<'de> for Netv6AddrVisitor {
 
 	fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
 		use core::str::FromStr;
-		Self::Value::from_str(value).map_err(de::Error::custom)
+		Self::Value::from_str(value)
+			.map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &self))
 	}
 }
 


### PR DESCRIPTION
Now instead of just calling `Error::custom`, we describe what we got and what we expected to the user. Smart!