### PR TITLE
Add Net.*Addr#is_cidr method

### DIFF
--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -31,6 +31,18 @@ impl NetAddr {
 			Self::V6(v6) => IpAddr::V6(*v6.addr()),
 		}
 	}
+
+	/// Return whether the inner `Netv4Addr` or `Netv6Addr` is CIDR.
+	///
+	/// A `Netv4Addr` or `Netv6Addr` is CIDR if and only if its underlying
+	/// netmask is "left contigous"; that is, if its bit pattern is a given
+	/// number of ones followed by a remaining group of zeroes.
+	pub fn is_cidr(&self) -> bool {
+		match self {
+			Self::V4(v4) => v4.is_cidr(),
+			Self::V6(v6) => v6.is_cidr(),
+		}
+	}
 }
 
 mod broadcast;

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -58,3 +58,44 @@ mod partialord;
 mod de;
 #[cfg(feature = "serde")]
 mod ser;
+
+#[cfg(test)]
+mod tests {
+	use super::NetAddr;
+
+	mod is_cidr {
+		use super::*;
+
+		mod v4 {
+			use super::*;
+
+			#[test]
+			fn non_cidr_returns_false() {
+				let netaddr: NetAddr = "0.0.0.0/255.255.127.0".parse().unwrap();
+				assert_eq!(netaddr.is_cidr(), false);
+			}
+
+			#[test]
+			fn cidr_returns_true() {
+				let netaddr: NetAddr = "0.0.0.0/255.255.192.0".parse().unwrap();
+				assert_eq!(netaddr.is_cidr(), true);
+			}
+		}
+
+		mod v6 {
+			use super::*;
+
+			#[test]
+			fn non_cidr_returns_false() {
+				let netaddr: NetAddr = "::/ffff:ffff:fff::".parse().unwrap();
+				assert_eq!(netaddr.is_cidr(), false);
+			}
+
+			#[test]
+			fn cidr_returns_true() {
+				let netaddr: NetAddr = "::/ffff:ffff:fffc::".parse().unwrap();
+				assert_eq!(netaddr.is_cidr(), true);
+			}
+		}
+	}
+}

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -21,6 +21,13 @@ impl Netv4Addr {
 		&self.addr
 	}
 
+	pub fn is_cidr(&self) -> bool {
+		let mask: u32 = self.mask.into();
+		let ones: u32 = mask.count_ones();
+		let cidr_mask: u32 = u32::max_value().checked_shl(32 - ones).unwrap_or(0);
+		mask == cidr_mask
+	}
+
 	/// Create a new `Netv4Addr` from the given `addr` and `mask`.
 	///
 	/// Masks the given `addr` value with the given `mask` before

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -21,6 +21,7 @@ impl Netv4Addr {
 		&self.addr
 	}
 
+	#[allow(clippy::trivially_copy_pass_by_ref)]
 	pub fn is_cidr(&self) -> bool {
 		let mask: u32 = self.mask.into();
 		let ones: u32 = mask.count_ones();

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -102,6 +102,30 @@ mod tests {
 		}
 	}
 
+	mod is_cidr {
+		use super::*;
+
+		#[test]
+		fn non_cidr_returns_false() {
+			let netaddr: Netv4Addr = Netv4Addr {
+				mask: "255.127.255.0".parse().unwrap(),
+				addr: "0.0.0.0".parse().unwrap(),
+			};
+
+			assert_eq!(netaddr.is_cidr(), false);
+		}
+
+		#[test]
+		fn cidr_returns_true() {
+			let netaddr: Netv4Addr = Netv4Addr {
+				mask: "255.224.0.0".parse().unwrap(),
+				addr: "0.0.0.0".parse().unwrap(),
+			};
+
+			assert_eq!(netaddr.is_cidr(), true);
+		}
+	}
+
 	mod new {
 		use super::*;
 

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -21,6 +21,13 @@ impl Netv6Addr {
 		&self.addr
 	}
 
+	pub fn is_cidr(&self) -> bool {
+		let mask: u128 = self.mask.into();
+		let ones: u32 = mask.count_ones();
+		let cidr_mask: u128 = u128::max_value().checked_shl(128 - ones).unwrap_or(0);
+		mask == cidr_mask
+	}
+
 	/// Create a new `Netv6Addr` from the given `addr` and `mask`.
 	///
 	/// Masks the given `addr` value with the given `mask` before

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -99,6 +99,30 @@ mod tests {
 		}
 	}
 
+	mod is_cidr {
+		use super::*;
+
+		#[test]
+		fn non_cidr_returns_false() {
+			let netaddr: Netv6Addr = Netv6Addr {
+				mask: "ffff:ffff:ffff:7f7f::0".parse().unwrap(),
+				addr: "::".parse().unwrap(),
+			};
+
+			assert_eq!(netaddr.is_cidr(), false);
+		}
+
+		#[test]
+		fn cidr_returns_true() {
+			let netaddr: Netv6Addr = Netv6Addr {
+				mask: "ffff:ffff:ffff:fffc::0".parse().unwrap(),
+				addr: "::".parse().unwrap(),
+			};
+
+			assert_eq!(netaddr.is_cidr(), true);
+		}
+	}
+
 	mod new {
 		use super::*;
 


### PR DESCRIPTION
Per the spec in #68.

This PR only adds the methods, and does not adjust any additional things.