### PR TITLE
Un-derive Ord and instead provide our own impl

### DIFF
--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -6,7 +6,7 @@ use std::net::Ipv4Addr;
 /// Internally, this structure includes two values; an `Ipv4Addr`
 /// representing the network address (`addr`), and another
 /// representing the netmask (`mask`).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Netv4Addr {
 	mask: Ipv4Addr,
 	addr: Ipv4Addr,
@@ -61,6 +61,7 @@ mod from;
 mod fromstr;
 mod hash;
 mod merge;
+mod ord;
 mod partialord;
 
 #[cfg(feature = "serde")]

--- a/src/netv4addr/ord.rs
+++ b/src/netv4addr/ord.rs
@@ -1,0 +1,49 @@
+use super::Netv4Addr;
+use core::cmp::Ordering;
+
+impl Ord for Netv4Addr {
+	fn cmp(&self, other: &Self) -> Ordering {
+		match self.addr().cmp(other.addr()) {
+			Ordering::Equal => self.mask().cmp(other.mask()),
+			ordering => ordering,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Netv4Addr;
+	use core::cmp::Ordering;
+
+	#[test]
+	fn different_networks() {
+		let a: Netv4Addr = "1.0.0.0/8".parse().unwrap();
+		let b: Netv4Addr = "2.0.0.0/8".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Less)
+	}
+
+	#[test]
+	fn different_netmasks() {
+		let a: Netv4Addr = "1.0.0.0/7".parse().unwrap();
+		let b: Netv4Addr = "1.0.0.0/8".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Less)
+	}
+
+	#[test]
+	fn different() {
+		let a: Netv4Addr = "1.0.0.0/8".parse().unwrap();
+		let b: Netv4Addr = "0.0.0.0/24".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Greater)
+	}
+
+	#[test]
+	fn equal() {
+		let a: Netv4Addr = "1.0.0.0/8".parse().unwrap();
+		let b: Netv4Addr = "1.0.0.0/8".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Equal)
+	}
+}

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -6,7 +6,7 @@ use std::net::Ipv6Addr;
 /// Internally, this structure includes two values; an `Ipv6Addr`
 /// representing the network address (`addr`), and another
 /// representing the netmask (`mask`).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Netv6Addr {
 	mask: Ipv6Addr,
 	addr: Ipv6Addr,
@@ -54,6 +54,7 @@ mod from;
 mod fromstr;
 mod hash;
 mod merge;
+mod ord;
 mod partialord;
 
 #[cfg(feature = "serde")]

--- a/src/netv6addr/ord.rs
+++ b/src/netv6addr/ord.rs
@@ -1,0 +1,49 @@
+use crate::netv6addr::Netv6Addr;
+use core::cmp::Ordering;
+
+impl Ord for Netv6Addr {
+	fn cmp(&self, other: &Self) -> Ordering {
+		match self.addr().cmp(other.addr()) {
+			Ordering::Equal => self.mask().cmp(other.mask()),
+			ordering => ordering,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Netv6Addr;
+	use core::cmp::Ordering;
+
+	#[test]
+	fn different_networks() {
+		let a: Netv6Addr = "2001:db8:0:0::0/64".parse().unwrap();
+		let b: Netv6Addr = "2001:db8:0:1::0/64".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Less)
+	}
+
+	#[test]
+	fn different_netmasks() {
+		let a: Netv6Addr = "2001:db8:0:0::0/63".parse().unwrap();
+		let b: Netv6Addr = "2001:db8:0:0::0/64".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Less)
+	}
+
+	#[test]
+	fn different() {
+		let a: Netv6Addr = "ff02::1/16".parse().unwrap();
+		let b: Netv6Addr = "2001:db8:0:1::0/64".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Greater)
+	}
+
+	#[test]
+	fn equal() {
+		let a: Netv6Addr = "2001:db8:dead:beef::0/64".parse().unwrap();
+		let b: Netv6Addr = "2001:db8:dead:beef::0/64".parse().unwrap();
+
+		assert_eq!(a.cmp(&b), Ordering::Equal)
+	}
+}


### PR DESCRIPTION
This should have the exact same semantics; we're just shelling out to the inner types as before. This resolves a new clippy lint on beta.