### PR TITLE
Fix some Clippy lints; Update Changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.10.0] - 2021-07-06
+### Changed
+- **Breaking**: `Netv4Addr::addr`, `Netv4Addr::mask`, `Netv6Addr::addr`, and `Netv6Addr::mask` all now return `Ipv4Addr` or `Ipv6Addr` respectively instead of `&Ipv4Addr` or `&Ipv6Addr`.
+
+- **Breaking**: Replaced the `derive`'d `Ord` impl with our own explicit implementation.
+  If you were using our old ordering, bare in mind that the behavior has changed.
+
+  Previously, we just used the derived `Ord` comparison on the underlying `Ip<...>Addr` structs in field-wise ordering.
+  Now, a `Net<...>Addr` struct is considered greater than another if its `addr` is equal but its mask is greater, or otherwise if its `addr` is greater.
+  For example, `1.0.0.0/8` < `2.0.0.0/8`, `1.0.0.0/7` < `1.0.0.0/8`, etc.
+
+- Internal fixes for the tests
+- Adjusted CI configuration
+
 ## [0.9.0] - 2020-02-26
 ### Changed
 - **Breaking**: Adjusted the signature of the `Contains` trait to take a type parameter.

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -72,13 +72,13 @@ mod tests {
 			#[test]
 			fn non_cidr_returns_false() {
 				let netaddr: NetAddr = "0.0.0.0/255.255.127.0".parse().unwrap();
-				assert_eq!(netaddr.is_cidr(), false);
+				assert!(!netaddr.is_cidr());
 			}
 
 			#[test]
 			fn cidr_returns_true() {
 				let netaddr: NetAddr = "0.0.0.0/255.255.192.0".parse().unwrap();
-				assert_eq!(netaddr.is_cidr(), true);
+				assert!(netaddr.is_cidr());
 			}
 		}
 
@@ -88,13 +88,13 @@ mod tests {
 			#[test]
 			fn non_cidr_returns_false() {
 				let netaddr: NetAddr = "::/ffff:ffff:fff::".parse().unwrap();
-				assert_eq!(netaddr.is_cidr(), false);
+				assert!(!netaddr.is_cidr());
 			}
 
 			#[test]
 			fn cidr_returns_true() {
 				let netaddr: NetAddr = "::/ffff:ffff:fffc::".parse().unwrap();
-				assert_eq!(netaddr.is_cidr(), true);
+				assert!(netaddr.is_cidr());
 			}
 		}
 	}

--- a/src/netaddr.rs
+++ b/src/netaddr.rs
@@ -19,16 +19,16 @@ impl NetAddr {
 	/// Get the "netmask" part of the inner `Netv4Addr` or the `Netv6Addr`.
 	pub fn mask(&self) -> IpAddr {
 		match self {
-			Self::V4(v4) => IpAddr::V4(*v4.mask()),
-			Self::V6(v6) => IpAddr::V6(*v6.mask()),
+			Self::V4(v4) => IpAddr::V4(v4.mask()),
+			Self::V6(v6) => IpAddr::V6(v6.mask()),
 		}
 	}
 
 	/// Get the "network" part of the inner `Netv4Addr` or the `Netv6Addr`.
 	pub fn addr(&self) -> IpAddr {
 		match self {
-			Self::V4(v4) => IpAddr::V4(*v4.addr()),
-			Self::V6(v6) => IpAddr::V6(*v6.addr()),
+			Self::V4(v4) => IpAddr::V4(v4.addr()),
+			Self::V6(v6) => IpAddr::V6(v6.addr()),
 		}
 	}
 

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -13,12 +13,12 @@ pub struct Netv4Addr {
 }
 
 impl Netv4Addr {
-	pub const fn mask(&self) -> &Ipv4Addr {
-		&self.mask
+	pub const fn mask(&self) -> Ipv4Addr {
+		self.mask
 	}
 
-	pub const fn addr(&self) -> &Ipv4Addr {
-		&self.addr
+	pub const fn addr(&self) -> Ipv4Addr {
+		self.addr
 	}
 
 	#[allow(clippy::trivially_copy_pass_by_ref)]
@@ -85,7 +85,7 @@ mod tests {
 
 			assert_eq!(
 				netaddr.mask(),
-				&"255.255.255.255".parse::<Ipv4Addr>().unwrap()
+				"255.255.255.255".parse::<Ipv4Addr>().unwrap()
 			);
 		}
 	}
@@ -100,7 +100,7 @@ mod tests {
 				addr: "0.0.0.0".parse().unwrap(),
 			};
 
-			assert_eq!(netaddr.addr(), &"0.0.0.0".parse::<Ipv4Addr>().unwrap());
+			assert_eq!(netaddr.addr(), "0.0.0.0".parse::<Ipv4Addr>().unwrap());
 		}
 	}
 
@@ -138,8 +138,8 @@ mod tests {
 
 			let netaddr: Netv4Addr = Netv4Addr::new(addr, mask);
 
-			assert_eq!(netaddr.mask(), &mask);
-			assert_eq!(netaddr.addr(), &"192.0.0.0".parse::<Ipv4Addr>().unwrap());
+			assert_eq!(netaddr.mask(), mask);
+			assert_eq!(netaddr.addr(), "192.0.0.0".parse::<Ipv4Addr>().unwrap());
 		}
 	}
 }

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -8,8 +8,8 @@ use std::net::Ipv4Addr;
 /// representing the netmask (`mask`).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Netv4Addr {
-	mask: Ipv4Addr,
 	addr: Ipv4Addr,
+	mask: Ipv4Addr,
 }
 
 impl Netv4Addr {

--- a/src/netv4addr.rs
+++ b/src/netv4addr.rs
@@ -114,7 +114,7 @@ mod tests {
 				addr: "0.0.0.0".parse().unwrap(),
 			};
 
-			assert_eq!(netaddr.is_cidr(), false);
+			assert!(!netaddr.is_cidr());
 		}
 
 		#[test]
@@ -124,7 +124,7 @@ mod tests {
 				addr: "0.0.0.0".parse().unwrap(),
 			};
 
-			assert_eq!(netaddr.is_cidr(), true);
+			assert!(netaddr.is_cidr());
 		}
 	}
 

--- a/src/netv4addr/broadcast.rs
+++ b/src/netv4addr/broadcast.rs
@@ -6,8 +6,8 @@ impl Broadcast for Netv4Addr {
 	type Output = Ipv4Addr;
 
 	fn broadcast(&self) -> Ipv4Addr {
-		let netmask: u32 = (*self.mask()).into();
-		let network: u32 = (*self.addr()).into();
+		let netmask: u32 = self.mask().into();
+		let network: u32 = self.addr().into();
 		let broadcast: u32 = network | !netmask;
 		broadcast.into()
 	}

--- a/src/netv4addr/broadcast.rs
+++ b/src/netv4addr/broadcast.rs
@@ -6,8 +6,8 @@ impl Broadcast for Netv4Addr {
 	type Output = Ipv4Addr;
 
 	fn broadcast(&self) -> Ipv4Addr {
-		let netmask: u32 = self.mask().clone().into();
-		let network: u32 = self.addr().clone().into();
+		let netmask: u32 = (*self.mask()).into();
+		let network: u32 = (*self.addr()).into();
 		let broadcast: u32 = network | !netmask;
 		broadcast.into()
 	}

--- a/src/netv4addr/contains.rs
+++ b/src/netv4addr/contains.rs
@@ -13,7 +13,7 @@ impl Contains<std::net::IpAddr> for Netv4Addr {
 
 impl Contains<std::net::Ipv4Addr> for Netv4Addr {
 	fn contains(&self, other: &std::net::Ipv4Addr) -> bool {
-		other.mask(self.mask()) == *self.addr()
+		other.mask(&self.mask()) == self.addr()
 	}
 }
 
@@ -28,7 +28,7 @@ impl Contains<crate::NetAddr> for Netv4Addr {
 
 impl Contains<Netv4Addr> for Netv4Addr {
 	fn contains(&self, other: &Netv4Addr) -> bool {
-		other.addr().mask(self.mask()) == *self.addr()
+		other.addr().mask(&self.mask()) == self.addr()
 	}
 }
 

--- a/src/netv4addr/display.rs
+++ b/src/netv4addr/display.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 impl fmt::Display for Netv4Addr {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let mask: u32 = (*self.mask()).into();
+		let mask: u32 = self.mask().into();
 		let ones = mask.count_ones();
 		let cidr_mask: u32 = u32::max_value().checked_shl(32 - ones).unwrap_or(0);
 

--- a/src/netv4addr/fromstr.rs
+++ b/src/netv4addr/fromstr.rs
@@ -52,12 +52,7 @@ impl FromStr for Netv4Addr {
 
 		match (address, cidr, right_addr) {
 			(Ok(addr), Ok(cidr), _) => {
-				let mask: u32 = u32::max_value()
-					^ match u32::max_value().checked_shr(cidr) {
-						Some(k) => k,
-						None => 0_u32,
-					};
-
+				let mask: u32 = u32::max_value() ^ u32::max_value().checked_shr(cidr).unwrap_or(0_u32);
 				let mask: Ipv4Addr = mask.into();
 
 				Ok(Self::new(addr, mask))

--- a/src/netv4addr/merge.rs
+++ b/src/netv4addr/merge.rs
@@ -7,10 +7,10 @@ impl Merge for Netv4Addr {
 	type Output = Option<Self>;
 
 	fn merge(&self, other: &Self) -> Self::Output {
-		let addr: u32 = self.addr().clone().into();
-		let mask: u32 = self.mask().clone().into();
-		let other_addr: u32 = other.addr().clone().into();
-		let other_mask: u32 = other.mask().clone().into();
+		let addr: u32 = (*self.addr()).into();
+		let mask: u32 = (*self.mask()).into();
+		let other_addr: u32 = (*other.addr()).into();
+		let other_mask: u32 = (*other.mask()).into();
 
 		let mask: u32 = match mask.cmp(&other_mask) {
 			Ordering::Equal => mask << 1,

--- a/src/netv4addr/merge.rs
+++ b/src/netv4addr/merge.rs
@@ -7,10 +7,10 @@ impl Merge for Netv4Addr {
 	type Output = Option<Self>;
 
 	fn merge(&self, other: &Self) -> Self::Output {
-		let addr: u32 = (*self.addr()).into();
-		let mask: u32 = (*self.mask()).into();
-		let other_addr: u32 = (*other.addr()).into();
-		let other_mask: u32 = (*other.mask()).into();
+		let addr: u32 = self.addr().into();
+		let mask: u32 = self.mask().into();
+		let other_addr: u32 = other.addr().into();
+		let other_mask: u32 = other.mask().into();
 
 		let mask: u32 = match mask.cmp(&other_mask) {
 			Ordering::Equal => mask << 1,

--- a/src/netv4addr/ord.rs
+++ b/src/netv4addr/ord.rs
@@ -3,8 +3,8 @@ use core::cmp::Ordering;
 
 impl Ord for Netv4Addr {
 	fn cmp(&self, other: &Self) -> Ordering {
-		match self.addr().cmp(other.addr()) {
-			Ordering::Equal => self.mask().cmp(other.mask()),
+		match self.addr().cmp(&other.addr()) {
+			Ordering::Equal => self.mask().cmp(&other.mask()),
 			ordering => ordering,
 		}
 	}

--- a/src/netv4addr/partialord.rs
+++ b/src/netv4addr/partialord.rs
@@ -3,8 +3,8 @@ use core::cmp::Ordering;
 
 impl PartialOrd for Netv4Addr {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		match self.addr().partial_cmp(other.addr()) {
-			Some(Ordering::Equal) => self.mask().partial_cmp(other.mask()),
+		match self.addr().partial_cmp(&other.addr()) {
+			Some(Ordering::Equal) => self.mask().partial_cmp(&other.mask()),
 			Some(ordering) => Some(ordering),
 			None => None,
 		}

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -8,8 +8,8 @@ use std::net::Ipv6Addr;
 /// representing the netmask (`mask`).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Netv6Addr {
-	mask: Ipv6Addr,
 	addr: Ipv6Addr,
+	mask: Ipv6Addr,
 }
 
 impl Netv6Addr {

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -13,12 +13,12 @@ pub struct Netv6Addr {
 }
 
 impl Netv6Addr {
-	pub const fn mask(&self) -> &Ipv6Addr {
-		&self.mask
+	pub const fn mask(&self) -> Ipv6Addr {
+		self.mask
 	}
 
-	pub const fn addr(&self) -> &Ipv6Addr {
-		&self.addr
+	pub const fn addr(&self) -> Ipv6Addr {
+		self.addr
 	}
 
 	pub fn is_cidr(&self) -> bool {
@@ -78,7 +78,7 @@ mod tests {
 
 			assert_eq!(
 				netaddr.mask(),
-				&"ffff:ffff:ffff:ffff::0".parse::<Ipv6Addr>().unwrap()
+				"ffff:ffff:ffff:ffff::0".parse::<Ipv6Addr>().unwrap()
 			);
 		}
 	}
@@ -95,7 +95,7 @@ mod tests {
 
 			assert_eq!(
 				netaddr.addr(),
-				&"2001:db8:dead:beef::0".parse::<Ipv6Addr>().unwrap()
+				"2001:db8:dead:beef::0".parse::<Ipv6Addr>().unwrap()
 			);
 		}
 	}
@@ -134,10 +134,10 @@ mod tests {
 
 			let netaddr: Netv6Addr = Netv6Addr::new(addr, mask);
 
-			assert_eq!(netaddr.mask(), &mask);
+			assert_eq!(netaddr.mask(), mask);
 			assert_eq!(
 				netaddr.addr(),
-				&"2001:db8:dead:be00::0".parse::<Ipv6Addr>().unwrap()
+				"2001:db8:dead:be00::0".parse::<Ipv6Addr>().unwrap()
 			);
 		}
 	}

--- a/src/netv6addr.rs
+++ b/src/netv6addr.rs
@@ -110,7 +110,7 @@ mod tests {
 				addr: "::".parse().unwrap(),
 			};
 
-			assert_eq!(netaddr.is_cidr(), false);
+			assert!(!netaddr.is_cidr());
 		}
 
 		#[test]
@@ -120,7 +120,7 @@ mod tests {
 				addr: "::".parse().unwrap(),
 			};
 
-			assert_eq!(netaddr.is_cidr(), true);
+			assert!(netaddr.is_cidr());
 		}
 	}
 

--- a/src/netv6addr/contains.rs
+++ b/src/netv6addr/contains.rs
@@ -13,7 +13,7 @@ impl Contains<std::net::IpAddr> for Netv6Addr {
 
 impl Contains<std::net::Ipv6Addr> for Netv6Addr {
 	fn contains(&self, other: &std::net::Ipv6Addr) -> bool {
-		other.mask(self.mask()) == *self.addr()
+		other.mask(&self.mask()) == self.addr()
 	}
 }
 
@@ -28,7 +28,7 @@ impl Contains<crate::NetAddr> for Netv6Addr {
 
 impl Contains<Netv6Addr> for Netv6Addr {
 	fn contains(&self, other: &Netv6Addr) -> bool {
-		other.addr().mask(self.mask()) == *self.addr()
+		other.addr().mask(&self.mask()) == self.addr()
 	}
 }
 

--- a/src/netv6addr/display.rs
+++ b/src/netv6addr/display.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 impl fmt::Display for Netv6Addr {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let mask: u128 = (*self.mask()).into();
+		let mask: u128 = self.mask().into();
 		let ones = mask.count_ones();
 		let cidr_mask: u128 = u128::max_value().checked_shl(128 - ones).unwrap_or(0);
 

--- a/src/netv6addr/fromstr.rs
+++ b/src/netv6addr/fromstr.rs
@@ -52,11 +52,7 @@ impl FromStr for Netv6Addr {
 
 		match (address, cidr, right_addr) {
 			(Ok(addr), Ok(cidr), _) => {
-				let mask: u128 = u128::max_value()
-					^ match u128::max_value().checked_shr(cidr) {
-						Some(k) => k,
-						None => 0_u128,
-					};
+				let mask: u128 = u128::max_value() ^ u128::max_value().checked_shr(cidr).unwrap_or(0_u128);
 
 				let mask: Ipv6Addr = mask.into();
 

--- a/src/netv6addr/merge.rs
+++ b/src/netv6addr/merge.rs
@@ -7,10 +7,10 @@ impl Merge for Netv6Addr {
 	type Output = Option<Self>;
 
 	fn merge(&self, other: &Self) -> Self::Output {
-		let addr: u128 = (*self.addr()).into();
-		let mask: u128 = (*self.mask()).into();
-		let other_addr: u128 = (*other.addr()).into();
-		let other_mask: u128 = (*other.mask()).into();
+		let addr: u128 = self.addr().into();
+		let mask: u128 = self.mask().into();
+		let other_addr: u128 = other.addr().into();
+		let other_mask: u128 = other.mask().into();
 
 		let mask: u128 = match mask.cmp(&other_mask) {
 			Ordering::Equal => mask << 1,

--- a/src/netv6addr/merge.rs
+++ b/src/netv6addr/merge.rs
@@ -7,10 +7,10 @@ impl Merge for Netv6Addr {
 	type Output = Option<Self>;
 
 	fn merge(&self, other: &Self) -> Self::Output {
-		let addr: u128 = self.addr().clone().into();
-		let mask: u128 = self.mask().clone().into();
-		let other_addr: u128 = other.addr().clone().into();
-		let other_mask: u128 = other.mask().clone().into();
+		let addr: u128 = (*self.addr()).into();
+		let mask: u128 = (*self.mask()).into();
+		let other_addr: u128 = (*other.addr()).into();
+		let other_mask: u128 = (*other.mask()).into();
 
 		let mask: u128 = match mask.cmp(&other_mask) {
 			Ordering::Equal => mask << 1,

--- a/src/netv6addr/ord.rs
+++ b/src/netv6addr/ord.rs
@@ -3,8 +3,8 @@ use core::cmp::Ordering;
 
 impl Ord for Netv6Addr {
 	fn cmp(&self, other: &Self) -> Ordering {
-		match self.addr().cmp(other.addr()) {
-			Ordering::Equal => self.mask().cmp(other.mask()),
+		match self.addr().cmp(&other.addr()) {
+			Ordering::Equal => self.mask().cmp(&other.mask()),
 			ordering => ordering,
 		}
 	}

--- a/src/netv6addr/partialord.rs
+++ b/src/netv6addr/partialord.rs
@@ -3,8 +3,8 @@ use core::cmp::Ordering;
 
 impl PartialOrd for Netv6Addr {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		match self.addr().partial_cmp(other.addr()) {
-			Some(Ordering::Equal) => self.mask().partial_cmp(other.mask()),
+		match self.addr().partial_cmp(&other.addr()) {
+			Some(Ordering::Equal) => self.mask().partial_cmp(&other.mask()),
 			Some(ordering) => Some(ordering),
 			None => None,
 		}


### PR DESCRIPTION
- Use `assert!(..)` instead of `assert_eq!(.., bool)` ([`bool_assert_comparison`](https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison))
- Use `Copy` trait on return value (`&Ip...Addr`) of `mask()` and `addr()` instead of `Clone`ing them.  (I think the compiler might optimize this, but this makes sure that we're just copying.) ([`clone_on_copy`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy))
- Use `unwrap_or(0)` instead of manually implementing with a `match` ([`manual_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or))
- Reorder struct fields to resolve the pedantic [`inconsistent_order`](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor) lint.  Now they are alphabetical, and also `addr` comes first as I'd expect.